### PR TITLE
Correct file case applied

### DIFF
--- a/src/oslayer/win/known_folder.h
+++ b/src/oslayer/win/known_folder.h
@@ -15,7 +15,7 @@
 #      define _ARM_
 #    endif  // __amd64__
 #  endif    // _MSC_VER
-#  include <Shlobj.h>
+#  include <shlobj.h>
 
 namespace rll::oslayer::win {
   [[nodiscard]] std::filesystem::path known_folder_path(::KNOWNFOLDERID id);


### PR DESCRIPTION
It is important for cross compilation that `#  include <shlobj.h>` must start from lowercase 's'. As for now - it starts with uppercase 'S' which leads to compilation errors when cross compiling on linux for windows